### PR TITLE
fix ?# bug

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
 	// Listen for changes in hash in the URL. If an MD file is found to have changed,
 	// refresh the page to solve the problem of using a single digital comment issue for the entire website.
 	window.onhashchange = function (event) {
-		if (event.newURL.split('?')[0] !== event.oldURL.split('?')[0]) {
+		if (event.newURL !== event.oldURL) {
 			location.reload()
 		}
 	}
@@ -47,11 +47,9 @@
 		clientSecret: 'ce9d01cd05fa48581c5315ad87aedd77113de48b',
 		repo: 'swdocissues',
 		owner: 'caodg',
-		admin: ['KouweiLee', 'caodg'],
+		admin: ['caodg','KouweiLee'],
 		id : location.hash.match(/#(.*?)([?]|$)/)[1].substr(0, 50),
 		title: `${location.hash.match(/#(.*?)([?]|$)/)[1]}`, 
-		createIssueManually : true, 
-		// distractionFreeMode: false
 		})
   </script>
   <!-- Docsify v4 -->


### PR DESCRIPTION
When url is `xxx/?#/xxx`, it has a bug that web dosen't refresh so that comment area is always the same. This pr fixes it. 

But when a user logs in for the first time, there is still a bug with the URL of the callback page, which needs to be fixed later